### PR TITLE
Commands and Handling

### DIFF
--- a/randobot/handler.py
+++ b/randobot/handler.py
@@ -14,3 +14,60 @@ class RandoHandler(RaceHandler):
         self.generator = generator
         self.loop = asyncio.get_event_loop()
         self.loop_ended = False
+
+    async def begin(self):
+        self.state["permalink"] = STANDARD_RACE_PERMALINK
+        
+    async def ex_francais(self, args):
+        self.state["use_french"] = True
+        await self.send_message("Bot responses will now also be in French.")
+        await self.send_message("Translate 'Bot responses will now also be in French.' to French.")
+
+    async def ex_permalink(self, args):
+        if not self.state.get("permalink_available"):
+            await self.send_message("There is no permalink! Please use !rollseed to get a permalink")
+            if self.state.get("use_french"):
+                await self.send_message("Translate 'There is no permalink! Please use !rollseed to get a permalink' to French")
+            return
+        permalink = self.state.get("permalink")
+        await self.send_message(f"The permalink is: {permalink}")
+        if self.state.get("use_french"):
+            await self.send_message(f"Translate 'The permalink is: {permalink}' to French.")
+            
+    @monitor_cmd
+    async def ex_lock(self, args):
+        self.state["locked"] = True
+        await self.send_message("Seed rolling is now locked.")
+        if self.state.get("use_french"):
+            await self.send_message("Translate 'Seed rolling is now locked.' to French.")
+
+    @monitor_cmd
+    async def ex_unlock(self, args):
+        self.state["locked"] = False
+        await self.send_message("Seed rolling is now unlocked")
+        if self.state.get("use_french"):
+            await self.send_message("Translate 'Seed rolling is now locked' to French.")
+
+    async def ex_rollseed(self, args):
+        if self.state.get("locked"):
+            await self.send_message("Seed rolling is locked! Only the creator of this room, a race monitor, or a moderator can roll a seed.")
+            if self.state.get("use_french"):
+                await self.send_message("Translate 'Seed rolling is locked! Only the creator of this room, a race monitor, or a moderator can roll a seed.'")
+            return
+            
+        if self.state.get("permalink_available"):
+            await self.send_message("The seed is already rolled! Use !permalink to view it.")
+            if self.state.get("use_french"):
+                await self.send_message("Translate 'The seed is already rolled! Use !permalink to view it.' to French.")
+
+        await self.send_message("Rolling seed.....")
+        generated_seed = self.generator.generator_seed(self.state.get("permalink"), self.state.get("generate_spoiler_log"))
+        permalink = generated_seed.get("permalink")
+
+        self.logger.info(permalink)
+
+        self.state["permalink"] = permalink
+        self.state["permalink_available"] = True
+
+        await self.send_message(f"Permalink: {permalink]}")
+        await self.set_raceinfo(f" - {permalink}", False, False)


### PR DESCRIPTION
Some basic race commands, and since I know SSR has a large French community, I added in an option to have the bot use French as well as English.

-Notes
`STANDARD_RACE_SETTINGS` is set to WWR settings, once the official release comes out for SSR that will have to be changed.
`generator.py` can be adjusted to not generate a filename. Since there isn't any high level TAS tools, no need to worry about that. Potentially could use a random Prefix/Suffix to prevent possible splicing.
It might be good to separate the messaging into a separate class in order to avoid having so much `if self.state.get("use_french")` everywhere.